### PR TITLE
Issue77 griffiths survey

### DIFF
--- a/irish_townlands/templates/irish_townlands/activity.html
+++ b/irish_townlands/templates/irish_townlands/activity.html
@@ -1,7 +1,7 @@
 {% extends 'irish_townlands/townland_base.html' %}
 {% load i18n l10n humanize %}
 
-{% block title %}{% trans "Mapping Acitivity" %}{% endblock %}
+{% block title %}{% trans "Mapping Activity" %}{% endblock %}
 {% block header %}{% trans "Mapping Activity" %}{% endblock %}
 
 {% block body %}

--- a/irish_townlands/templates/irish_townlands/townland_detail.html
+++ b/irish_townlands/templates/irish_townlands/townland_detail.html
@@ -25,7 +25,7 @@
         <li><a href="#map">{% trans "Map" %} ↓</a></li>
         <li><a href="#area">{% trans "Area" %} ↓</a></li>
         <li><a href="#borders">{% trans "Bordering Townlands" %} ↓</a></li>
-        <li><a href="#census">{% trans "Census Search" %} ↓</a></li>
+        <li><a href="#records">{% trans "Records Search" %} ↓</a></li>
         <li><a href="#osm">{% trans "OpenStreetMap" %}↓</a></li>
     </ul>
 
@@ -149,13 +149,13 @@
         <p>{% blocktrans %}We don't know about any subtownlands in {{ townland_name }}.{% endblocktrans %}
     {% endif %}
 
-    <a name="census"></a>
-    <h2>{% trans "Census Search" %}</h2>
+    <a name="records"></a>
+    <h2>{% trans "Records Search" %}</h2>
     <p>
-        {% blocktrans %}Interested in Geneological / ancestors who may have lived in {{ townland_name }}?{% endblocktrans %}
-        <ul>
-            <li><a href="http://www.census.nationalarchives.ie/search/results.jsp?census_year=1911&surname=&firstname=&county={{ townland.county.name }}&townland={{ townland.name }}&ded=&age=&sex=&search=Search&relationToHead=&religion=&education=&occupation=&marriageStatus=&birthplace=&language=&deafdumb=&marriageYears=&childrenBorn=&childrenLiving=">{% blocktrans %}Search the 1911 Irish Census for {{ townland_name }}{% endblocktrans %}</a></li>
-            <li><a href="http://www.census.nationalarchives.ie/search/results.jsp?census_year=1901&surname=&firstname=&county={{ townland.county.name }}&townland={{ townland.name }}&ded=&age=&sex=&search=Search&relationToHead=&religion=&education=&occupation=&marriageStatus=&birthplace=&language=&deafdumb=&marriageYears=&childrenBorn=&childrenLiving=">{% blocktrans %}Search the 1901 Irish Census for {{ townland_name }}{% endblocktrans %}</a></li>
+        {% blocktrans %}Curious to see who lived in {{ townland_name }} in the past? Maybe even seeing scans of their handwritten census returns? {% endblocktrans %}
+        <ul>http://www.census.nationalarchives.ie/search/results.jsp?census_year=1901&county19011911=Kildare&townland=Newtown&ded=Rathmore&search=Search
+            <li><a href="http://www.census.nationalarchives.ie/search/results.jsp?census_year=1911&county19011911={{ townland.county.name }}&townland={{ townland.name }}&ded={{ townland.ed }}&search=Search">{% blocktrans %}Search the 1911 Irish Census for {{ townland_name }}{% endblocktrans %}</a></li>
+            <li><a href="http://www.census.nationalarchives.ie/search/results.jsp?census_year=1901&county19011911={{ townland.county.name }}&townland={{ townland.name }}&ded={{ townland.ed }}&search=Search">{% blocktrans %}Search the 1901 Irish Census for {{ townland_name }}{% endblocktrans %}</a></li>
             <li><a href="http://www.askaboutireland.ie/griffith-valuation/index.xml?action=doPlaceSearch&Submit.x=51&Submit.y=16&Submit=Submit&freetext={{ townland.name }}&countyname={{ townland.county.name }}&baronyname={{ townland.barony }}&unionname=&parishname={{ townland.civil_parish }}">{% blocktrans %}Search the Griffith's Valuation (1847-1864) for {{ townland_name }}{% endblocktrans %}</a></li>
         </ul>
     </p>

--- a/irish_townlands/templates/irish_townlands/townland_detail.html
+++ b/irish_townlands/templates/irish_townlands/townland_detail.html
@@ -156,6 +156,7 @@
         <ul>
             <li><a href="http://www.census.nationalarchives.ie/search/results.jsp?census_year=1911&surname=&firstname=&county={{ townland.county.name }}&townland={{ townland.name }}&ded=&age=&sex=&search=Search&relationToHead=&religion=&education=&occupation=&marriageStatus=&birthplace=&language=&deafdumb=&marriageYears=&childrenBorn=&childrenLiving=">{% blocktrans %}Search the 1911 Irish Census for {{ townland_name }}{% endblocktrans %}</a></li>
             <li><a href="http://www.census.nationalarchives.ie/search/results.jsp?census_year=1901&surname=&firstname=&county={{ townland.county.name }}&townland={{ townland.name }}&ded=&age=&sex=&search=Search&relationToHead=&religion=&education=&occupation=&marriageStatus=&birthplace=&language=&deafdumb=&marriageYears=&childrenBorn=&childrenLiving=">{% blocktrans %}Search the 1901 Irish Census for {{ townland_name }}{% endblocktrans %}</a></li>
+            <li><a href="http://www.askaboutireland.ie/griffith-valuation/index.xml?action=doPlaceSearch&Submit.x=51&Submit.y=16&Submit=Submit&freetext={{ townland.name }}&countyname={{ townland.county.name }}&baronyname={{ townland.barony }}&unionname=&parishname={{ townland.civil_parish }}">{% blocktrans %}Search the Griffith's Valuation (1847-1864) for {{ townland_name }}{% endblocktrans %}</a></li>
         </ul>
     </p>
 

--- a/irish_townlands/templates/irish_townlands/townland_detail.html
+++ b/irish_townlands/templates/irish_townlands/townland_detail.html
@@ -153,7 +153,7 @@
     <h2>{% trans "Records Search" %}</h2>
     <p>
         {% blocktrans %}Curious to see who lived in {{ townland_name }} in the past? Maybe even seeing scans of their handwritten census returns? {% endblocktrans %}
-        <ul>http://www.census.nationalarchives.ie/search/results.jsp?census_year=1901&county19011911=Kildare&townland=Newtown&ded=Rathmore&search=Search
+        <ul>
             <li><a href="http://www.census.nationalarchives.ie/search/results.jsp?census_year=1911&county19011911={{ townland.county.name }}&townland={{ townland.name }}&ded={{ townland.ed }}&search=Search">{% blocktrans %}Search the 1911 Irish Census for {{ townland_name }}{% endblocktrans %}</a></li>
             <li><a href="http://www.census.nationalarchives.ie/search/results.jsp?census_year=1901&county19011911={{ townland.county.name }}&townland={{ townland.name }}&ded={{ townland.ed }}&search=Search">{% blocktrans %}Search the 1901 Irish Census for {{ townland_name }}{% endblocktrans %}</a></li>
             <li><a href="http://www.askaboutireland.ie/griffith-valuation/index.xml?action=doPlaceSearch&Submit.x=51&Submit.y=16&Submit=Submit&freetext={{ townland.name }}&countyname={{ townland.county.name }}&baronyname={{ townland.barony }}&unionname=&parishname={{ townland.civil_parish }}">{% blocktrans %}Search the Griffith's Valuation (1847-1864) for {{ townland_name }}{% endblocktrans %}</a></li>

--- a/irish_townlands/views.py
+++ b/irish_townlands/views.py
@@ -502,7 +502,7 @@ def detailed_stats_for_period(from_date, to_date):
         if num_eds > 0:
             summary.append(ungettext("%d ED", "%d EDs", num_eds) % num_eds)
         if num_cps > 0:
-            summary.append(ungettext("%d civil parish", "%d civil parises", num_cps) % num_cps)
+            summary.append(ungettext("%d civil parish", "%d civil parishes", num_cps) % num_cps)
         if num_baronies > 0:
             summary.append(ungettext("%d barony", "%d baronies", num_baronies) % num_baronies)
         if num_subtownlands > 0:


### PR DESCRIPTION
A first pull request to propose the following changes (and test out the git contribution process):
* Fix typo in title of Activity page
* Fix typo in summaries of Activity page (generated by views.py)
* Update Census Search section:
  * 1901/11 unused query terms removed
  * 1901/11 county field renamed to county19011911 as that is what the target site seems to require
  * Added link to Griffith Valuation on AskAboutIreland.ie for the townland
  * Renamed section to Records Search as it is not just census info any more.
  * Updated intro to the Records Search section to make it more generic.

Please note I have not tested the changes - not sure if/how to regenerate the site locally here. I believe some refinements will be required. E.g. "Firmount East" won't return Griffith results but "Firmount" or "Firmount%2C+East" will. Also "St. Catherines" won't return results but "St Catherines" will.